### PR TITLE
Replace old/missed references to `TimerObject` with `Timer` for consistency

### DIFF
--- a/Timer/keywords.txt
+++ b/Timer/keywords.txt
@@ -1,4 +1,4 @@
-TimerObject 			KEYWORD1
+Timer 			KEYWORD1
 setInterval				KEYWORD2
 setEnabled				KEYWORD2
 setSingleShot			KEYWORD2

--- a/docs/timer.rst
+++ b/docs/timer.rst
@@ -81,11 +81,11 @@ Full example - Two timers
 Documentation
 -------------
 
-**TimerObject(unsigned long int ms);** - Create a Timer with the time
+**Timer(unsigned long int ms);** - Create a Timer with the time
 
-**TimerObject(unsigned long int ms, CallBackType callback);** Create a Timer with time and callback
+**Timer(unsigned long int ms, CallBackType callback);** Create a Timer with time and callback
 
-**TimerObject(unsigned long int ms, CallBackType callback, bool isSingle);** Create a Timer with time, callback and set if is single shot
+**Timer(unsigned long int ms, CallBackType callback, bool isSingle);** Create a Timer with time, callback and set if is single shot
 	
 **void setInterval(unsigned long int ms);** - Set callback interval
 


### PR DESCRIPTION
It looks like you refactored the `TimerObject` class to be just `Timer` but some docs still use the old names, so I updated them.
