### PR TITLE
Timer: Cleanup and fix millis() rollover bug

### DIFF
--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -74,7 +74,7 @@ bool Timer::Tick(){
 		return false;
 	if(LastTime > millis()*2)//millis restarted
 		LastTime = 0;
-	if ((unsigned long int)(millis() - LastTime) >= msInterval) {
+	if (millis() - LastTime >= msInterval) {
 		LastTime = millis();
 		if(isSingleShot())
 			setEnabled(false);
@@ -89,14 +89,14 @@ unsigned long int Timer::getInterval(){
 }
 
 unsigned long int Timer::getCurrentTime(){
-	return (unsigned long int)(millis() - LastTime);
+	return millis() - LastTime;
 }
 
 unsigned long int Timer::getRemaining() {
 	if (blEnabled) {
-		return msInterval - (unsigned long int)(millis() - LastTime);
+		return msInterval - (millis() - LastTime);
 	} else {
-		return msInterval - (unsigned long int)(millis() - (millis() - DiffTime));
+		return msInterval - (millis() - (millis() - DiffTime));
 	}
 }
 

--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -28,7 +28,7 @@ Timer::Timer(unsigned long int ms, CallBackType callback, bool isSingle){
 }
 
 void Timer::setInterval(unsigned long int ms){
-	msInterval = (ms > 0) ? ms : 0;
+	msInterval = ms;
 }
 
 void Timer::setEnabled(bool Enabled){

--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -19,19 +19,7 @@
 
 #include "Timer.h"
 
-Timer::Timer(unsigned long int ms){
-	Create(ms, NULL, false);
-}
-
-Timer::Timer(unsigned long int ms, CallBackType callback){
-	Create(ms, callback, false);
-}
-
 Timer::Timer(unsigned long int ms, CallBackType callback, bool isSingle){
-	Create(ms, callback, isSingle);
-}
-
-void Timer::Create(unsigned long int ms, CallBackType callback, bool isSingle){
 	setInterval(ms);
 	setEnabled(false);
 	setSingleShot(isSingle);

--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -72,8 +72,6 @@ void Timer::Update(){
 bool Timer::Tick(){
 	if(!blEnabled)
 		return false;
-	if(LastTime > millis()*2)//millis restarted
-		LastTime = 0;
 	if (millis() - LastTime >= msInterval) {
 		LastTime = millis();
 		if(isSingleShot())

--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -96,7 +96,7 @@ unsigned long int Timer::getRemaining() {
 	if (blEnabled) {
 		return msInterval - (millis() - LastTime);
 	} else {
-		return msInterval - (millis() - (millis() - DiffTime));
+		return msInterval - DiffTime;
 	}
 }
 

--- a/Timer/Timer.h
+++ b/Timer/Timer.h
@@ -27,7 +27,6 @@ typedef void (*CallBackType)();
 
 class Timer{
 private:
-	void Create(unsigned long int ms, CallBackType callback, bool isSingle);
 	unsigned long int msInterval;
 	bool blEnabled;
 	bool blSingleShot;
@@ -37,9 +36,7 @@ private:
 	unsigned long DiffTime;//used when I pause the Timer and need to resume
 
 public:
-	Timer(unsigned long int ms);
-	Timer(unsigned long int ms, CallBackType callback);
-	Timer(unsigned long int ms, CallBackType callback, bool isSingle);
+	Timer(unsigned long int ms, CallBackType callback = NULL, bool isSingle = false);
 	~Timer();
 
 	void setInterval(unsigned long int ms);


### PR DESCRIPTION
This pull request does some cleanup on the Timer module, removing code that has no effect other than making the source longer and harder to read. It also removes the lines intended to detect a `millis()` rollover event:

```c++
if(LastTime > millis()*2)//millis restarted
        LastTime = 0;
```

These lines are responsible from the issue #4. Besides, they serve no useful purpose, as the test that follows is [rollover safe](https://arduino.stackexchange.com/q/12587).