### PR TITLE
Doc: remove link to cybersquatted blog

### DIFF
--- a/docs/timer.rst
+++ b/docs/timer.rst
@@ -9,12 +9,6 @@ There are two types of timers
 * **Single-shot**: Run only once. If you need to run a single shot timer again, use the method ->Start();
 
 
-Tutorials
----------
-
-* `Using Timer Object – interval and singleshot callback – in Arduino <https://bytedebugger.wordpress.com/2014/06/18/tutorial-using-timer-object-interval-and-singleshot-callback-in-arduino/>`_
-
-
 Simple Example
 --------------
 


### PR DESCRIPTION
The blog bytedebugger.wordpress.com seems to have been taken over by a cybersquatter. The full link to the tutorial redirects me to a scam telling me that I have won a Samsung Galaxy S9, iPhone X or iPad Air 2.